### PR TITLE
refactor: standardize array-to-string conversion and constant declarations

### DIFF
--- a/events-and-bookings.php
+++ b/events-and-bookings.php
@@ -1401,7 +1401,7 @@ class Eab_EventsHub {
 
 		$capable = false;
 
-		if ( preg_match( '/(_event|_events)/i', join( $caps, ',' ) ) > 0 ) {
+		if ( preg_match( '/(_event|_events)/i', implode( ',', $caps) ) > 0 ) {
 		    if ( in_array( 'administrator', $current_user->roles ) ) {
 				foreach ( $caps as $cap ) {
 				    $allcaps[$cap] = 1;
@@ -1564,7 +1564,7 @@ function eab_autoshow_map_off ( $opts ) {
 	return $opts;
 }
 
-define( 'EAB_PLUGIN_BASENAME', basename( dirname( __FILE__ ) ), true );
+define( 'EAB_PLUGIN_BASENAME', basename( dirname( __FILE__ ) ));
 define( 'EAB_PLUGIN_DIR', trailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'EAB_PLUGIN_URL', trailingslashit( plugin_dir_url( __FILE__ ) ) );
 
@@ -1575,10 +1575,10 @@ if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 
 
 if ( !defined( 'EAB_OLD_EVENTS_EXPIRY_LIMIT' ) ) {
-	define( 'EAB_OLD_EVENTS_EXPIRY_LIMIT', 100, true );
+	define( 'EAB_OLD_EVENTS_EXPIRY_LIMIT', 100);
 }
 if ( !defined( 'EAB_MAX_UPCOMING_EVENTS' ) ) {
-	define( 'EAB_MAX_UPCOMING_EVENTS', 500, true );
+	define( 'EAB_MAX_UPCOMING_EVENTS', 500);
 }
 
 require_once EAB_PLUGIN_DIR . 'lib/class_eab_error_reporter.php';

--- a/lib/class_eab_addon_handler.php
+++ b/lib/class_eab_addon_handler.php
@@ -5,7 +5,7 @@
 class Eab_AddonHandler {
 
 	private function __construct () {
-		define( 'EAB_PLUGIN_ADDONS_DIR', EAB_PLUGIN_DIR . 'lib/plugins', true );
+		define( 'EAB_PLUGIN_ADDONS_DIR', EAB_PLUGIN_DIR . 'lib/plugins');
 		$this->_load_active_plugins();
 	}
 

--- a/lib/default_filters.php
+++ b/lib/default_filters.php
@@ -372,4 +372,4 @@ if (defined('EAB_OPTMIZIE_SCRIPT_LOAD') && EAB_OPTMIZIE_SCRIPT_LOAD) {
 // End script concatenation
 
 // Twitter delta threshold correction
-define('EAB_OAUTH_TIMESTAMP_DELTA_THRESHOLD', 10, true);
+define('EAB_OAUTH_TIMESTAMP_DELTA_THRESHOLD', 10);


### PR DESCRIPTION
This commit improves code consistency and potential performance by making the following changes:

* **events-and-bookings.php:** Replaced `join()` with `implode()` for robust array-to-string conversion.
* **events-and-bookings.php, lib/class_eab_addon_handler.php, lib/default_filters.php:** Removed the third argument (`true`) from `define()` calls for case-sensitive constants (as of PHP 7.3).