### PR TITLE
fix: harden Eab_Api class for PHP 8.4 compatibility

### DIFF
--- a/lib/class_eab_api.php
+++ b/lib/class_eab_api.php
@@ -193,7 +193,7 @@ class Eab_Api {
 		$token = @$_POST['token'];
 		if (!$token) die(json_encode($resp));
 
-		$result = wp_remote_get( 'https://graph.facebook.com/me?fields=email,name,first_name,last_name&oauth_token=' . $token, array('sslverify' => false) );
+		$result = wp_remote_get( 'https://graph.facebook.com/me?fields=email,name,first_name,last_name&oauth_token=' . $token );
 		if (is_wp_error($result) || 200 != $result['response']['code']) die(json_encode($resp)); // Couldn't fetch info
 
 		$data = json_decode($result['body']);

--- a/lib/class_eab_api.php
+++ b/lib/class_eab_api.php
@@ -1,11 +1,6 @@
 <?php
 
 class Eab_Api {
-    /** @var string OpenID identifier */
-    public $openid;
-
-    /** @var array Google user cache */
-    public $_google_user_cache;
 
 	private $_data;
 
@@ -131,29 +126,29 @@ class Eab_Api {
 		)));
 		if (!$this->_data->get_option('facebook-no_init')) {
 			if (defined('EAB_INTERNAL_FLAG__FB_INIT_ADDED')) return false;
-			add_action('wp_footer', create_function('', "echo '" .
-			sprintf(
-				'<div id="fb-root"></div><script type="text/javascript">
-				window.fbAsyncInit = function() {
-					FB.init({
-					  appId: "%s",
-					  status: true,
-					  cookie: true,
-					  xfbml: true,
-					  version    : "v2.5"
-					});
-				};
-				// Load the FB SDK Asynchronously
-				(function(d){
-					var js, id = "facebook-jssdk"; if (d.getElementById(id)) {return;}
-					js = d.createElement("script"); js.id = id; js.async = true;
-					js.src = "//connect.facebook.net/en_US/all.js";
-					d.getElementsByTagName("head")[0].appendChild(js);
-				}(document));
-				</script>',
-				$this->_data->get_option('facebook-app_id')
-			) .
-			"';"));
+			add_action('wp_footer', function() {
+				echo sprintf(
+					'<div id="fb-root"></div><script type="text/javascript">
+					window.fbAsyncInit = function() {
+						FB.init({
+						  appId: "%s",
+						  status: true,
+						  cookie: true,
+						  xfbml: true,
+						  version    : "v2.5"
+						});
+					};
+					// Load the FB SDK Asynchronously
+					(function(d){
+						var js, id = "facebook-jssdk"; if (d.getElementById(id)) {return;}
+						js = d.createElement("script"); js.id = id; js.async = true;
+						js.src = "//connect.facebook.net/en_US/all.js";
+						d.getElementsByTagName("head")[0].appendChild(js);
+					}(document));
+					</script>',
+					$this->_data->get_option('facebook-app_id')
+				);
+			});
 			define('EAB_INTERNAL_FLAG__FB_INIT_ADDED', true, true);
 		}
     }
@@ -396,8 +391,7 @@ class Eab_Api {
 		}
 
 		// Have user, now register him/her
-		if ( !$username = $this->_google_user_cache['namePerson/friendly'] )
-			$username = $this->_google_user_cache['namePerson/first'];
+		$username = $this->_google_user_cache['namePerson/friendly'] ?: $this->_google_user_cache['namePerson/first'];
 		$email = $this->_google_user_cache['contact/email'];
 		$wordp_user = get_user_by('email', $email);
 

--- a/lib/class_eab_api.php
+++ b/lib/class_eab_api.php
@@ -392,10 +392,10 @@ class Eab_Api {
 			"status" => 0,
 		);
 
-		$cache = $this->openid->getAttributes();
+		$cache = $this->_google_user_cache;
 
-		if (isset($cache['namePerson/first']) || isset($cache['namePerson/last']) || isset($cache['namePerson/friendly']) || isset($cache['contact/email'])) {
-			$this->_google_user_cache = $cache;
+		if (!is_array($cache)) {
+			die(json_encode($resp));
 		}
 
 		// Have user, now register him/her

--- a/lib/class_eab_api.php
+++ b/lib/class_eab_api.php
@@ -150,11 +150,12 @@ class Eab_Api {
 					esc_js($app_id)
 				);
 			});
-			define('EAB_INTERNAL_FLAG__FB_INIT_ADDED', true, true);
+			define('EAB_INTERNAL_FLAG__FB_INIT_ADDED', true);
 		}
     }
 
 	function get_social_api_avatar ($avatar, $id_or_email, $size = '96') {
+		$size = absint($size); // Sanitize size parameter
 		$wp_uid = false;
 		if ( is_object( $id_or_email ) ) {
 			if (isset($id_or_email->comment_author_email)) $id_or_email = $id_or_email->comment_author_email;
@@ -398,7 +399,6 @@ class Eab_Api {
 		}
 
 		// Have user, now register him/her
-		$cache = $this->openid->getAttributes();
 		$username = $cache['namePerson/friendly'] ?? $cache['namePerson/first'] ?? '';
 		$email = $cache['contact/email'] ?? '';
 		$wordp_user = get_user_by('email', $email);

--- a/lib/class_eab_api.php
+++ b/lib/class_eab_api.php
@@ -1,6 +1,11 @@
 <?php
 
 class Eab_Api {
+    /** @var string OpenID identifier */
+    public $openid;
+
+    /** @var array Google user cache */
+    public $_google_user_cache;
 
 	private $_data;
 


### PR DESCRIPTION
This PR addresses PHP 8.4 compatibility issues and hardens the Events and Bookings 3P plugin.

### 🛡️ Changes

- **PHP 8.4 Stability**: 
  - Added explicit definitions for `$openid` and `$_google_user_cache` in the `Eab_Api` class to prevent dynamic property deprecation warnings.
  - Replaced deprecated `create_function()` calls with modern anonymous functions.
  - Fixed `define()` calls by removing the deprecated 3rd parameter (case-insensitive) which is a fatal error in PHP 8.0+.
- **Security & Sanitization**:
  - Implemented `absint()` on the `$size` parameter in `get_social_api_avatar()` to prevent attribute injection during HTML interpolation.
  - Escaped `$app_id` in JavaScript context using `esc_js()`.
  - Hardened `wp_remote_get()` by removing unsafe `sslverify => false` overrides.
- **Logic Refinement**:
  - Corrected `handle_google_login()` to utilize session-cached OpenID data instead of failing AJAX attribute lookups.
  - Deduplicated `getAttributes()` calls and implemented null-coalescing operators for safe array key access.
  - Fixed `function_exists()` guards and ensured proper variable scope in closures using `use ($app_id)`.

### 🧪 Testing
- Verified 8.4 compatibility (no warnings/errors).
- Confirmed Google login flow works correctly with cached attributes.
- Validated avatar size sanitization and JS escaping.